### PR TITLE
Fixed MAC HWADDR

### DIFF
--- a/plug.cc
+++ b/plug.cc
@@ -361,7 +361,7 @@ int pkt4_receive(CalloutHandle& handle) {
         Pkt4Ptr query;
         handle.getArgument("query4", query);
         uint8_t packet_type = query->getType();
-        HWAddrPtr hwaddr = query->getMAC(HWAddr::HWADDR_SOURCE_ANY);
+        HWAddrPtr hwaddr = query->getHWAddr();
 
         // Store the id we search with so it is available down the road.
         handle.setContext(query_hwaddr_label, hwaddr);

--- a/plug.cc
+++ b/plug.cc
@@ -384,7 +384,7 @@ int subnet4_select(CalloutHandle& handle) {
     try {
         Pkt4Ptr query;
         handle.getArgument("query4", query);
-        HWAddrPtr hwaddr = query->getMAC(HWAddr::HWADDR_SOURCE_ANY);
+        HWAddrPtr hwaddr = query->getHWAddr();
 
         Subnet4Ptr subnet;
         const Subnet4Collection *subnets;


### PR DESCRIPTION
Modified getMAC in HWAddrPtr to use ciaddr instead of local router's mac (in case of DHCP relay)